### PR TITLE
Handle nested repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.1.0] - 2020-08-07
+
+- Added support for nested repositories; now the extension works also when a GIT repository
+is not opened as the root folder of a project or workspace
+- Fix: the extension should no longer trigger a "Command '...' resulted in an error" message
+when trying to run one of the commands from a folder without a GIT repository
+
 ## [1.0.0] - 2020-06-13
 
 - Added configuration settings to customise contextual menu items visibility

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 	"extensionDependencies": [
 		"vscode.git"
 	],
+	"extensionKind": ["ui"],
 	"activationEvents": [
 		"workspaceContains:.git",
 		"workspaceContains:**/.gitignore",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-sublime-merge",
 	"displayName": "Sublime Merge for VSCode",
 	"description": "Open repository, file history, blame, etc.",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"license": "MIT",
 	"author": {
 		"name": "Giovanni Derks"
@@ -31,7 +31,14 @@
 		"vscode.git"
 	],
 	"activationEvents": [
-		"workspaceContains:.git"
+		"workspaceContains:.git",
+		"workspaceContains:**/.gitignore",
+		"workspaceContains:**/.git/config",
+		"onCommand:vscsm.openInSublimeMerge",
+		"onCommand:vscsm.blameInSublimeMerge",
+		"onCommand:vscsm.fileHistoryInSublimeMerge",
+		"onCommand:vscsm.lineHistoryInSublimeMerge",
+		"onCommand:vscsm.myCommitsInSublimeMerge"
 	],
 	"main": "./out/extension.js",
 	"contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,19 +4,23 @@
 import { ExtensionContext } from 'vscode';
 import { Configuration } from './configuration';
 import { LoggingService } from "./lib/LoggingService";
-import { registerCommands } from './commands';
+import { Repositories } from "./lib/Repositories";
+import { RegisterCommands } from './commands';
 import { StatusBar } from './status_bar';
 
 let statusBar: StatusBar;
+let repositories: Repositories;
 
 // this method is called when the extension is activated
 export function activate(context: ExtensionContext) {
 	const config = new Configuration();
 	const loggingService = new LoggingService(config);
+	repositories = new Repositories(loggingService);
+	const registerCommands = new RegisterCommands(context, repositories, loggingService);
 
-	registerCommands(context);
+	registerCommands.init();
 
-	statusBar = new StatusBar(config.showInStatusBar, loggingService);
+	statusBar = new StatusBar(config.showInStatusBar, repositories, loggingService);
 	context.subscriptions.push(config.onDidShowInStatusBarChange(() => {
 		config.showInStatusBar ? statusBar.enable() : statusBar.disable();
 	}));
@@ -25,4 +29,5 @@ export function activate(context: ExtensionContext) {
 // this method is called when the extension is deactivated
 export function deactivate() {
 	statusBar.disposeSubscriptions();
+	repositories.disposeSubscriptions();
 }

--- a/src/lib/Repositories.ts
+++ b/src/lib/Repositories.ts
@@ -1,0 +1,94 @@
+'use strict';
+import * as vscode from 'vscode';
+import { API, APIState, GitExtension, Repository } from '../api/git';
+import { LoggingService } from './LoggingService';
+
+
+export class Repositories {
+	private _git: API;
+	private _loggingService: LoggingService;
+	private _subscriptions: vscode.Disposable[] = [];
+	private _initialized: boolean = false;
+
+	private _InitializedEvent = new vscode.EventEmitter<any>();
+	public readonly onDidInitialize: vscode.Event<any> = this._InitializedEvent.event;
+
+	private _ChangedRepositoriesEvent = new vscode.EventEmitter<any>();
+	public readonly onRepositoriesDidChange: vscode.Event<any> = this._ChangedRepositoriesEvent.event;
+
+	constructor(loggingService: LoggingService) {
+		this._loggingService = loggingService;
+		this._git = this._gitAPI;
+
+		this._handleDidChangeState(this._git.state);
+		this._setupSubscriptions();
+	}
+
+	private get _gitAPI(): API {
+		const gitExtension = vscode.extensions.getExtension<GitExtension>('vscode.git')!.exports;
+		return gitExtension.getAPI(1);
+	}
+
+	disposeSubscriptions() {
+		this._loggingService.logInfo('Repositories: Dispose Subscriptions');
+		this._subscriptions.every(subscription => {
+			subscription.dispose();
+		});
+		this._subscriptions = [];
+	}
+
+	private _setupSubscriptions() {
+		if (this._subscriptions.length === 0) {
+			this._subscriptions.push(this._git.onDidOpenRepository(this._handleOpenRepository, this));
+			this._subscriptions.push(this._git.onDidChangeState(this._handleDidChangeState, this));
+		}
+	}
+
+	private _handleOpenRepository(repo: Repository) {
+		if (!this._initialized) { return; }
+
+		this._loggingService.logInfo('_handleOpenRepository: ' + repo.rootUri.toString());
+
+		if (this._initialized) {
+			this._ChangedRepositoriesEvent.fire(true);
+		}
+	}
+
+	private _handleDidChangeState(state: APIState) {
+		if (state === 'initialized') {
+			this._loggingService.logInfo(`-- GIT ${state} --`);
+			this._initialized = true;
+			this._InitializedEvent.fire(true);
+		}
+	}
+
+	get repositories(): Repository[] {
+		if (this._initialized) {
+			return this._git.repositories;
+		}
+
+		return [];
+	}
+
+	repoForFile(fileUri: vscode.Uri): Repository | null {
+		if (fileUri.scheme !== 'file') { return null; }
+
+		const sortedRepos = this.sortedByPathDepth();
+		const foundRepo = sortedRepos.find(
+			repo => fileUri.toString().startsWith(repo.rootUri.toString())
+		);
+
+		this._loggingService.logInfo(`Sorted repos:`, sortedRepos.map(e => e.rootUri.toString()));
+		this._loggingService.logInfo(`Repo for ${fileUri.path}: ${foundRepo?.rootUri.path}`);
+
+		return foundRepo || null;
+	}
+
+	sortedByPathDepth() {
+		return this.repositories.sort(
+			(a, b) => {
+				return b.rootUri.path.length - a.rootUri.path.length;
+			}
+		);
+	}
+}

--- a/src/status_bar.ts
+++ b/src/status_bar.ts
@@ -2,18 +2,18 @@
 import * as vscode from 'vscode';
 import { API, APIState, GitExtension, Repository } from './api/git';
 import { LoggingService } from './lib/LoggingService';
+import { Repositories } from './lib/Repositories';
 
 export class StatusBar {
 	private _statusBar: vscode.StatusBarItem;
-	private _git: API;
 	private _loggingService: LoggingService;
-	private _workspaceRepos: { [key: number]: Repository } = {};
 	private _subscriptions: vscode.Disposable[] = [];
 	private _repoSubscriptions: vscode.Disposable[] = [];
+	private _repositories: Repositories;
 
-	constructor(show: boolean, loggingService: LoggingService) {
+	constructor(show: boolean, repositories: Repositories, loggingService: LoggingService) {
 		this._loggingService = loggingService;
-		this._git = this._gitAPI;
+		this._repositories = repositories;
 		this._statusBar = this._setup();
 
 		if (show) {
@@ -23,7 +23,7 @@ export class StatusBar {
 
 	enable() {
 		this._loggingService.logInfo('Enabling Status Bar');
-		this._loadRepositories();
+		this._setupRepositories();
 		this._setupSubscriptions();
 		this._statusBar.show();
 	}
@@ -36,7 +36,7 @@ export class StatusBar {
 
 	disposeSubscriptions() {
 		this._resetRepositories();
-		this._loggingService.logInfo('Dispose Subscriptions');
+		this._loggingService.logInfo('StatusBar: Dispose Subscriptions');
 		this._subscriptions.every(subscription => {
 			subscription.dispose();
 		});
@@ -46,14 +46,22 @@ export class StatusBar {
 	private _setupSubscriptions() {
 		if (this._subscriptions.length === 0) {
 			this._subscriptions.push(vscode.window.onDidChangeActiveTextEditor(this._handleActiveTextEditorChange, this));
-			this._subscriptions.push(this._git.onDidOpenRepository(this._handleOpenRepository, this));
-			this._subscriptions.push(this._git.onDidChangeState(this._handleDidChangeState, this));
+
 			this._subscriptions.push(
 				vscode.workspace.onDidChangeWorkspaceFolders(() => {
 					this._resetRepositories();
-					this._loadRepositories();
+					this._setupRepositories();
 				})
 			);
+
+			this._subscriptions.push(
+				this._repositories.onRepositoriesDidChange(() => {
+					this._resetRepositories();
+					this._setupRepositories();
+				})
+			);
+
+			this._subscriptions.push(this._repositories.onDidInitialize(this._setupRepositories, this));
 
 			this._loggingService.logInfo('Setup Subscriptions (' + this._subscriptions.length + ')');
 		}
@@ -72,7 +80,7 @@ export class StatusBar {
 
 		this._repoSubscriptions.push(
 			repo.state.onDidChange(() => {
-				this._loggingService.logInfo('Repo State Change');
+				this._loggingService.logInfo(`Repo State Change (${repo.rootUri.toString()})`);
 				this._updateStatusBarForActiveEditor();
 			})
 		);
@@ -80,7 +88,7 @@ export class StatusBar {
 		this._repoSubscriptions.push(
 			repo.ui.onDidChange(() => {
 				if (repo.ui.selected) {
-					this._loggingService.logInfo('Repo UI Change');
+					this._loggingService.logInfo(`Repo UI Change (${repo.rootUri.toString()})`);
 					this._updateStatusBar(repo);
 				}
 			})
@@ -107,7 +115,7 @@ export class StatusBar {
 		const unstaged = repo.state.workingTreeChanges.length;
 		const staged = repo.state.indexChanges.length;
 
-		this._loggingService.logInfo('Update Status Bar');
+		this._loggingService.logInfo(`Update Status Bar (${repo.rootUri.toString()})`);
 
 		this._statusBar.text = '$(git-branch) ' + unstaged + ' $(git-commit) ' + staged;
 		this._statusBar.tooltip = 'Open in Sublime Merge\n\nUnstaged: ' + unstaged + '\nTo be committed: ' + staged;
@@ -120,18 +128,9 @@ export class StatusBar {
 		}
 	}
 
-	private get _gitAPI(): API {
-		const gitExtension = vscode.extensions.getExtension<GitExtension>('vscode.git')!.exports;
-		return gitExtension.getAPI(1);
-	}
-
 	private _editorRepository(editor: vscode.TextEditor | undefined): Repository | null {
 		if (editor) {
-			const workspaceIndex = vscode.workspace.getWorkspaceFolder(editor.document.uri)!.index;
-
-			if (this._workspaceRepos[workspaceIndex]) {
-				return this._workspaceRepos[workspaceIndex];
-			}
+			return this._repositories.repoForFile(editor.document.uri);
 		}
 
 		return null;
@@ -154,39 +153,11 @@ export class StatusBar {
 	private _resetRepositories() {
 		this._loggingService.logInfo('Reset repositories');
 		this._disposeRepoSubscriptions();
-		this._workspaceRepos = {};
 	}
 
-	private _loadRepositories() {
-		if (this._git.state === 'initialized') {
-			this._git.repositories.forEach(repo => {
-				this._addWorkspaceRepo(repo);
-			});
-
-			this._loggingService.logInfo('Loaded workspace repositories');
-		}
-	}
-
-	private _addWorkspaceRepo(repo: Repository) {
-		const workspaceFolder = vscode.workspace.getWorkspaceFolder(repo.rootUri);
-
-		if (workspaceFolder && !this._workspaceRepos[workspaceFolder.index]) {
-			this._loggingService.logInfo('Add Workspace Repo. ' + workspaceFolder.index + ': ' + repo.rootUri.toString());
+	private _setupRepositories() {
+		this._repositories.repositories.forEach(repo => {
 			this._setupRepoSubscriptions(repo);
-			this._workspaceRepos[workspaceFolder.index] = repo;
-		}
-	}
-
-	private _handleOpenRepository(repo: Repository) {
-		this._loggingService.logInfo('_handleOpenRepository: ' + repo.rootUri.toString());
-		this._addWorkspaceRepo(repo);
-	}
-
-	private _handleDidChangeState(state: APIState) {
-		this._loggingService.logInfo('_handleDidChangeState: ' + state);
-
-		if (state === 'initialized') {
-			this._loadRepositories();
-		}
+		});
 	}
 }


### PR DESCRIPTION
These changes allow the extension to work also when a git repository
is only present in one or more sub-folder(s) of the current project.

The extension is still loaded only when required (e.g. when a git
repository is found or when one of the commands is invoked)