### PR TITLE
Windows: Send relative PATH in Posix format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.3.1] - 2021-02-11
+- Fix an issue on Windows where an incorrect file path was given to Sublime Merge
+when opening the current file (file / line history, etc.)
+
 ## [1.3.0] - 2020-11-27
 - Added configuration setting that allows to specify the path of the "smerge" executable
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-sublime-merge",
 	"displayName": "Sublime Merge for VSCode",
 	"description": "Open repository, file history, blame, etc.",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"license": "MIT",
 	"author": {
 		"name": "Giovanni Derks"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -33,7 +33,7 @@ export class RegisterCommands {
 			const editor = vscode.window.activeTextEditor;
 			if (editor) {
 				const selectionInfo = editor.selection;
-				this._runSublimeMerge(['blame', editor.document.fileName, String(selectionInfo.start.line)]);
+				this._runSublimeMerge(['blame', this._currentFileRelativePathToRepo(), String(selectionInfo.start.line)]);
 			}
 		});
 
@@ -140,8 +140,9 @@ export class RegisterCommands {
 		if (!fileUri) { return ''; }
 		const repoPath = this._getRepositoryPath(fileUri);
 		if (!repoPath) { return ''; }
+		const repoUri = vscode.Uri.file(repoPath);
 
-		return path.relative(repoPath, fileUri.fsPath);
+		return path.posix.relative(repoUri.path, fileUri.path);
 	}
 
 	private getGitConfig(param: string): string | null {


### PR DESCRIPTION
Fix an issue (#15) on Windows where an incorrect file path was given to
Sublime Merge when opening the current file (file / line history, etc.)