### PR TITLE
Version 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [1.3.2] - 2021-10-01
+- Security fixes
+
 ## [1.3.1] - 2021-02-11
 - Fix an issue on Windows where an incorrect file path was given to Sublime Merge
 when opening the current file (file / line history, etc.)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-sublime-merge",
-	"version": "1.2.0",
+	"version": "1.3.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1306,9 +1306,9 @@
 			"dev": true
 		},
 		"y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+			"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
 			"dev": true
 		},
 		"yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-sublime-merge",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -927,9 +927,9 @@
 			"dev": true
 		},
 		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
 		},
 		"picomatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -513,9 +513,9 @@
 			}
 		},
 		"glob-parent": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-			"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
 			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-sublime-merge",
 	"displayName": "Sublime Merge for VSCode",
 	"description": "Open repository, file history, blame, etc.",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"license": "MIT",
 	"author": {
 		"name": "Giovanni Derks"
@@ -15,7 +15,7 @@
 	},
 	"icon": "icon.png",
 	"engines": {
-		"vscode": "^1.48.0"
+		"vscode": "^1.50.0"
 	},
 	"categories": [
 		"Other"
@@ -30,7 +30,9 @@
 	"extensionDependencies": [
 		"vscode.git"
 	],
-	"extensionKind": ["ui"],
+	"extensionKind": [
+		"ui"
+	],
 	"activationEvents": [
 		"workspaceContains:.git",
 		"workspaceContains:**/.gitignore",


### PR DESCRIPTION
Security fixes:
- Bump y18n from 4.0.0 to 4.0.1
- Bump glob-parent from 5.1.1 to 5.1.2
- Bump path-parse from 1.0.6 to 1.0.7